### PR TITLE
Mobile: Create Training Data/Domain

### DIFF
--- a/FitTrack_iOS/FitTrack_iOS/Data/Mappers/TrainingDTOToDomainMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Mappers/TrainingDTOToDomainMapper.swift
@@ -1,0 +1,18 @@
+//
+//  TrainingDTOToDomainMapper.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+struct TrainingDTOToDomainMapper {
+    func map(_ dto: TrainingDTO) -> Training {
+        .init(id: dto.id,
+              name: dto.name,
+              goalId: dto.goalId,
+              date: dto.date
+        )
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Data/Models/TrainingDTO.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Models/TrainingDTO.swift
@@ -1,0 +1,15 @@
+//
+//  TrainingDTO.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+struct TrainingDTO: Decodable {
+    let id: UUID?
+    let name: String?
+    let goalId: UUID?
+    let date: Date?
+}

--- a/FitTrack_iOS/FitTrack_iOS/Data/Repository/TrainingRepository.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Repository/TrainingRepository.swift
@@ -1,0 +1,31 @@
+//
+//  UserRepository.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+protocol TrainingRepositoryProtocol {
+    func create(name: String, goalId: UUID) async throws -> Training
+}
+
+final class TrainingRepository: TrainingRepositoryProtocol {
+    private let apiSession: APISessionContract
+    
+    init(apiSession: APISessionContract = APISession.shared) {
+        self.apiSession = apiSession
+    }
+    
+    func create(name: String, goalId: UUID) async throws -> Training {
+        let trainginDTO = try await apiSession.request(
+            CreateTrainingURLequest(
+                name: name,
+                goalId: goalId
+            )
+        )
+        
+        return TrainingDTOToDomainMapper().map(trainginDTO)
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Data/Repository/TrainingRepository.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Repository/TrainingRepository.swift
@@ -20,7 +20,7 @@ final class TrainingRepository: TrainingRepositoryProtocol {
     
     func create(name: String, goalId: UUID) async throws -> Training {
         let trainginDTO = try await apiSession.request(
-            CreateTrainingURLequest(
+            CreateTrainingURLRequest(
                 name: name,
                 goalId: goalId
             )

--- a/FitTrack_iOS/FitTrack_iOS/Domain/Entities/Training.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Domain/Entities/Training.swift
@@ -1,0 +1,15 @@
+//
+//  Training.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+struct Training {
+    let id: UUID?
+    let name: String?
+    let goalId: UUID?
+    let date: Date?
+}

--- a/FitTrack_iOS/FitTrack_iOS/Domain/UseCases/CreateTrainingUseCase.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Domain/UseCases/CreateTrainingUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  CrateTrainingUseCase.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+protocol CreateTrainingUseCaseProtocol {
+    func run(name: String, goalId: UUID) async throws -> Training
+}
+
+final class CreateTrainingUseCase: CreateTrainingUseCaseProtocol {
+    private let trainingRepository: TrainingRepository
+    
+    init(trainingRepository: TrainingRepository = TrainingRepository()) {
+        self.trainingRepository = trainingRepository
+    }
+    
+    func run(name: String, goalId: UUID) async throws -> Training {
+        try await trainingRepository.create(name: name, goalId: goalId)
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Domain/UseCases/CreateTrainingUseCase.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Domain/UseCases/CreateTrainingUseCase.swift
@@ -12,9 +12,9 @@ protocol CreateTrainingUseCaseProtocol {
 }
 
 final class CreateTrainingUseCase: CreateTrainingUseCaseProtocol {
-    private let trainingRepository: TrainingRepository
+    private let trainingRepository: TrainingRepositoryProtocol
     
-    init(trainingRepository: TrainingRepository = TrainingRepository()) {
+    init(trainingRepository: TrainingRepositoryProtocol = TrainingRepository()) {
         self.trainingRepository = trainingRepository
     }
     

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/APIError.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/APIError.swift
@@ -28,10 +28,11 @@ extension APIError {
         )
     }
     
-    static func badRequest(url: String) -> Self {
+    static func badRequest(url: String, statusCode: Int?) -> Self {
         APIError(
             url: url,
-            reason: "Bad request"
+            reason: "The request could not be understood or was missing required parameters",
+            statusCode: statusCode
         )
     }
     

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/APISession.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/APISession.swift
@@ -49,6 +49,8 @@ final class APISession: APISessionContract {
                     throw APIError.decoding(url: request.path)
                 }
             }
+        case 400:
+            throw APIError.badRequest(url: request.path, statusCode: statusCode)
         case 401:
             throw APIError.unauthorized(url: request.path, statusCode: statusCode)
         default:

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CreateTrainingURLequest: URLRequestComponents {
+struct CreateTrainingURLRequest: URLRequestComponents {
     typealias Response = TrainingDTO
     var path: String = "/api/trainings"
     var httpMethod: HTTPMethod = .POST
@@ -22,7 +22,7 @@ struct CreateTrainingURLequest: URLRequestComponents {
     }
 }
 
-extension CreateTrainingURLequest {
+extension CreateTrainingURLRequest {
     struct Body: Encodable {
         let name: String
         let goalId: String

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
@@ -1,0 +1,31 @@
+//
+//  CreateTrainingURLRequest.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+
+struct CreateTrainingURLequest: URLRequestComponents {
+    typealias Response = TrainingDTO
+    var path: String = "/api/trainings"
+    var httpMethod: HTTPMethod = .POST
+    var authorized: Bool = true
+    var body: (any Encodable)?
+    
+    init(name: String, goalId: UUID) {
+        body = Body(
+            name: name,
+            goalId: goalId.uuidString
+        )
+    }
+}
+
+extension CreateTrainingURLequest {
+    struct Body: Encodable {
+        let name: String
+        let goalId: String
+        // TODO: Send exercises data
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
@@ -50,7 +50,7 @@ final class URLRequestBuilder {
             return urlRequest
         } catch {
             AppLogger.debug("Failed to create an URL request")
-            throw APIError.badRequest(url: urlRequestComponents.path)
+            throw APIError.badRequest(url: urlRequestComponents.path, statusCode: 400)
         }
     }
 }

--- a/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/LoginRepositoryTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/LoginRepositoryTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import FitTrack_iOS
 
 final class LoginRepositoryTests: XCTestCase {
-    var sut: LoginRepository!
+    var sut: LoginRepositoryProtocol!
 
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/LoginRepositoryTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/LoginRepositoryTests.swift
@@ -1,5 +1,5 @@
 //
-//  LoginRepositoryTest.swift
+//  LoginRepositoryTests.swift
 //  FitTrack_iOSTests
 //
 //  Created by Ana Ganfornina Arques on 8/9/25.

--- a/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/Mock/MockTrainingRepository.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/Mock/MockTrainingRepository.swift
@@ -1,0 +1,21 @@
+//
+//  MockTrainingRepository.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+@testable import FitTrack_iOS
+
+final class MockTrainingRepository: TrainingRepositoryProtocol {
+    var dataReceived: Training? = nil
+    
+    func create(name: String, goalId: UUID) async throws -> Training {
+        guard let dataReceived else {
+            throw AppError.network("The request could not be understood or was missing required parameters")
+        }
+        
+        return dataReceived
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/TrainingRepositoryTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/TrainingRepositoryTests.swift
@@ -1,0 +1,77 @@
+//
+//  TrainingRepositoryTests.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import XCTest
+@testable import FitTrack_iOS
+
+final class TrainingRepositoryTests: XCTestCase {
+    var sut: TrainingRepositoryProtocol!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let urlSessionConfiguration = URLSessionConfiguration.default
+        urlSessionConfiguration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession(configuration: urlSessionConfiguration)
+        let mockApiSession = APISession(urlSession: urlSession)
+        sut = TrainingRepository(apiSession: mockApiSession)
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
+    }
+    
+    func testCreateTraining_ShouldSucceed() async throws {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let url = try XCTUnwrap(request.url)
+            let httpURLResponse = try XCTUnwrap(MockURLProtocol.httpURLResponse(url: url))
+            let fileURL = try XCTUnwrap(Bundle(for: TrainingRepositoryTests.self).url(forResource: "training", withExtension: "json"))
+            let jwtData = try XCTUnwrap(Data(contentsOf: fileURL))
+            return (httpURLResponse, jwtData)
+        }
+        
+        // When
+        let training = try await sut.create(
+            name: "Fuerza: Full Body",
+            goalId: UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679") ?? UUID()
+        )
+        
+        // Then
+        let unwrappedTraining = try XCTUnwrap(training)
+        XCTAssertEqual(unwrappedTraining.id, UUID(uuidString: "DAB7C5C0-0579-4D01-A01D-002D3F6D8985"))
+        XCTAssertEqual(unwrappedTraining.name, "Fuerza: Full Body")
+        XCTAssertEqual(unwrappedTraining.goalId, UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679"))
+    }
+    
+    func testCreateTraining_ShouldReturnError() async throws {
+        // Given
+        MockURLProtocol.requestHandler = { request in
+            let url = try XCTUnwrap(request.url)
+            let request = try XCTUnwrap(MockURLProtocol.httpURLResponse(url: url, statusCode: 400))
+            return (request, Data())
+        }
+        
+       // When
+        var apiError: APIError?
+        do {
+            let _ = try await sut.create(
+                name: "Fuerza: Full Body",
+                goalId: UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679") ?? UUID()
+            )
+            XCTFail("Training error expected")
+        } catch let error as APIError {
+            apiError = error
+        }
+        
+        // Then
+        let badRequestAPIError = try XCTUnwrap(apiError)
+        XCTAssertEqual(badRequestAPIError.url, "/api/trainings")
+        XCTAssertEqual(badRequestAPIError.reason, "The request could not be understood or was missing required parameters")
+        XCTAssertEqual(badRequestAPIError.statusCode, 400)
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Domain/CreateTrainingUseCase.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Domain/CreateTrainingUseCase.swift
@@ -1,0 +1,59 @@
+//
+//  GetTrainingUseCase.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import XCTest
+@testable import FitTrack_iOS
+
+final class CreateTrainingCaseTests: XCTestCase {
+    var sut: CreateTrainingUseCaseProtocol!
+    var mockTrainingReposiory: MockTrainingRepository!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockTrainingReposiory = MockTrainingRepository()
+        sut = CreateTrainingUseCase(trainingRepository: mockTrainingReposiory)
+    }
+    
+    func testCreateTraining_ShouldReturnSuccess() async throws {
+        // Given
+        let trainingData = try XCTUnwrap(TrainingData.givenItem)
+        mockTrainingReposiory.dataReceived = trainingData
+        
+        // When
+        let training = try await sut.run(
+            name: "Fuerza: Full Body",
+            goalId: UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679") ?? UUID()
+        )
+        
+        // Then
+        let unwrappedTraining = try XCTUnwrap(training)
+        XCTAssertEqual(unwrappedTraining.id, UUID(uuidString: "DAB7C5C0-0579-4D01-A01D-002D3F6D8985"))
+        XCTAssertEqual(unwrappedTraining.name, "Fuerza: Full Body")
+        XCTAssertEqual(unwrappedTraining.goalId, UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679"))
+    }
+    
+    func testCreateTraining_WhenDataIsCorrupted() async throws {
+        // Given
+        mockTrainingReposiory.dataReceived = nil
+        
+        // When
+        var trainingError: AppError?
+        do {
+            let _ = try await sut.run(
+                name: "Fuerza: Full Body",
+                goalId: UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679") ?? UUID()
+            )
+            XCTFail("Training error expected")
+        } catch let error as AppError {
+            trainingError = error
+        }
+        
+        // Then
+        XCTAssertNotNil(trainingError)
+        XCTAssertEqual(trainingError?.reason, "The request could not be understood or was missing required parameters")
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Domain/CreateTrainingUseCase.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Domain/CreateTrainingUseCase.swift
@@ -1,5 +1,5 @@
 //
-//  GetTrainingUseCase.swift
+//  CreateTrainingUseCaseTests.swift
 //  FitTrack_iOS
 //
 //  Created by Ariana Rodríguez on 19/09/25.

--- a/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/AppStateTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/AppStateTests.swift
@@ -1,5 +1,5 @@
 //
-//  AppStateTest.swift
+//  AppStateTests.swift
 //  FitTrack_iOSTests
 //
 //  Created by Ana Ganfornina Arques on 5/9/25.

--- a/FitTrack_iOS/FitTrack_iOSTests/Stubs/TrainingData.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Stubs/TrainingData.swift
@@ -1,0 +1,17 @@
+//
+//  training.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 19/09/25.
+//
+
+import Foundation
+@testable import FitTrack_iOS
+
+enum TrainingData {
+    static let givenItem = Training(
+        id: UUID(uuidString: "DAB7C5C0-0579-4D01-A01D-002D3F6D8985"),
+        name: "Fuerza: Full Body",
+        goalId: UUID(uuidString: "E0D9DD1C-496F-4E9A-A944-44DB158A1679"),
+        date: Date())
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Stubs/training.json
+++ b/FitTrack_iOS/FitTrack_iOSTests/Stubs/training.json
@@ -1,0 +1,5 @@
+{
+    "goalId": "E0D9DD1C-496F-4E9A-A944-44DB158A1679",
+    "id": "DAB7C5C0-0579-4D01-A01D-002D3F6D8985",
+    "name": "Fuerza: Full Body"
+}


### PR DESCRIPTION
* Created the `CreateTrainingURLRequest` to make the `POST` to the API, also created the `DTOs` and `Mappers`
* Created the `TrainingRepository` to request the data to the api session and transform it from a DTO to a domain model
* Created the `CreateTrainingUseCase` to create a new training using a `name` and `goalId`
* Created Unit Tests for `ApiSession`, `Repository` and `UseCase`

<img width="502" height="403" alt="Captura de pantalla 2025-09-19 a las 7 45 22 p m" src="https://github.com/user-attachments/assets/b3803693-32de-4fe0-b13c-63acefc50764" />
