### PR TITLE
Mobile: Integrate Login request in View

### DIFF
--- a/FitTrack_iOS/FitTrack-iOS-Info.plist
+++ b/FitTrack_iOS/FitTrack-iOS-Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/FitTrack_iOS/FitTrack_iOS.xcodeproj/project.pbxproj
+++ b/FitTrack_iOS/FitTrack_iOS.xcodeproj/project.pbxproj
@@ -34,9 +34,22 @@
 		C3B3CE4A2E7C9843004B95B2 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		C3A2F55F2E7E6A1B0090A562 /* Exceptions for "FitTrack_iOS" folder in "FitTrack_iOS" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"FitTrack-iOS-Info.plist",
+			);
+			target = A1E8BEA62E69E940007218D4 /* FitTrack_iOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		A1E8BEA92E69E940007218D4 /* FitTrack_iOS */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				C3A2F55F2E7E6A1B0090A562 /* Exceptions for "FitTrack_iOS" folder in "FitTrack_iOS" target */,
+			);
 			path = FitTrack_iOS;
 			sourceTree = "<group>";
 		};
@@ -419,6 +432,7 @@
 				DEVELOPMENT_TEAM = DRKH5MTLPD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "FitTrack-iOS-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -447,6 +461,7 @@
 				DEVELOPMENT_TEAM = DRKH5MTLPD;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "FitTrack-iOS-Info.plist";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
@@ -16,8 +16,11 @@ final class URLRequestBuilder {
     
     private func url() throws -> URL {
         var urlComponents: URLComponents = URLComponents()
-        urlComponents.scheme = "https"
+        // TODO: Remplazar por htttps cuando el servidor sea remoto
+        urlComponents.scheme = "http"
         urlComponents.host = urlRequestComponents.host
+        // TODO: Remover el puerto cuando el servidor sea remoto
+        urlComponents.port = 8080
         urlComponents.path = urlRequestComponents.path
         
         if let queryParameters = urlRequestComponents.queryParameters, !queryParameters.isEmpty {

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/AppState.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/AppState.swift
@@ -11,6 +11,8 @@ import Foundation
 @Observable
 final class AppState: ObservableObject {
     var status = Status.none  // TODO: Cambiar a Status.none cuando sepamos qué hacer con la EmptyView
+    var inlineError: RegexLintError = .none
+    var fullScreenError: String?
     
     private var loginUseCase: LoginUseCaseProtocol
     private var getSessionUseCase: GetSessionUseCaseProtocol
@@ -53,11 +55,12 @@ final class AppState: ObservableObject {
                 try await loginUseCase.run(user: user, password: password)
                 status = .home
             } catch let error as RegexLintError {
-                // TODO: Update status with inline error
-                status = .none
+                status = .login
+                inlineError = error
             } catch let error as APIError {
-                // TODO: Update status with full screen error
-                status = .none
+                status = .login
+                inlineError = .none
+                fullScreenError = error.reason
             }
         }
     }

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/LoginView.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/LoginView.swift
@@ -13,6 +13,7 @@ struct LoginView: View {
     @State private var username = ""
     @State private var password = ""
     @State private var rememberMe = false
+    @State private var showAlert = false
     
     var body: some View {
         ZStack {
@@ -38,14 +39,23 @@ struct LoginView: View {
                         .background(Color.white)
                         .cornerRadius(15)
                         .padding(.horizontal)
-                    
+                        .textInputAutocapitalization(.never)
+                    if appState.inlineError == .email {
+                        Text(appState.inlineError.localizedDescription)
+                            .foregroundColor(.red)
+                            .font(.footnote)
+                    }
                     // Password Field
                     SecureField("Password", text: $password)
                         .padding()
                         .background(Color.white)
                         .cornerRadius(15)
                         .padding(.horizontal, 20)
-                    
+                    if appState.inlineError == .password {
+                        Text(appState.inlineError.localizedDescription)
+                            .foregroundColor(.red)
+                            .font(.footnote)
+                    }
                     // Horizontal container for Toggle "Remember me" and "Forgot Password"
                     HStack {
                         // Toggle "Remember me"
@@ -67,7 +77,16 @@ struct LoginView: View {
                     
                     // Login Button
                     Button {
-                        appState.performLogin(user: "UserTest", password: "UserPassword")
+                        appState.performLogin(
+                            user: username,
+                            password: password
+                        )
+                        
+                        DispatchQueue.main.async {
+                            if  appState.fullScreenError != nil {
+                                showAlert = true
+                            }
+                        }
                     } label: {
                         Text("Iniciar Sesión")
                             .font(.headline)
@@ -96,6 +115,19 @@ struct LoginView: View {
                 }  // 2nd VStack
             } // 1st VStack
             .padding()
+            .onChange(of: appState.fullScreenError, { oldValue, newValue in
+                showAlert = newValue != nil
+            })
+            .alert("Ocurrió un error", isPresented: $showAlert) {
+                Button("Aceptar", role: .cancel) {
+                    appState.fullScreenError = nil
+                    showAlert = false
+                }
+            } message: {
+                if let errorMessage = appState.fullScreenError {
+                    Text(errorMessage)
+                }
+            }
         } // ZStack
     }
 }


### PR DESCRIPTION
**Changes**
* Allowed `NSAllowsArbitraryLoads` to use `http`
* Enabled port 8080 in the builder to connect from server local
* Added inline and fullscreen errors to the App State, were added outside the `Status` because an error does not trigger a screen
* Then in UI I added some `Text` view for password and email to display the errors
* For an error not related to regex I added an alert error

**Screens**
<img width="200" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-20 at 09 18 19" src="https://github.com/user-attachments/assets/94173cec-096c-4ac0-9981-1cac5c8e4ccc" />

<img width="200" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-20 at 09 18 24" src="https://github.com/user-attachments/assets/d2a0af95-a811-4c85-a7be-4365aabbb1cd" />

<img width="200" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-20 at 09 18 19" src="https://github.com/user-attachments/assets/ce609584-46ae-4df5-9f8d-f509e47725db" />

**Server**
<img width="632" height="99" alt="Captura de pantalla 2025-09-20 a las 9 21 13 a m" src="https://github.com/user-attachments/assets/797e7463-42b9-49f3-8599-4c5a1f538854" />

**How to test it**
* Run the Vapor server in your local
* If the URL of your local is  http://127.0.0.1:8080 good! if not copy and paste it in `URLRequestComponents` but without the port
* Then create a user in Postman in the `Auth/register` you can use this body:

```
{
    "name": "Ana Ganfornina",
    "email": "ana@gmail.com",
    "password": "12345678",
    "role": "coach"
}
```

* Finally run the iOS app and try the login