### PR TITLE
Mobile: Fix HttpBody in Signup

### DIFF
--- a/FitTrack_iOS/FitTrack_iOS/Data/Mappers/ProfileDomainToDTOMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Mappers/ProfileDomainToDTOMapper.swift
@@ -18,13 +18,7 @@ struct ProfileDomainToDTOMapper {
                   height: domain.height
             )
         } else {
-            .init(name: domain.name,
-                  goal: nil,
-                  coachId: nil,
-                  age: nil,
-                  weight: nil,
-                  height: nil
-            )
+            .init(name: domain.name)
         }
     }
 }

--- a/FitTrack_iOS/FitTrack_iOS/Data/Mappers/ProfileDomainToDTOMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Mappers/ProfileDomainToDTOMapper.swift
@@ -8,17 +8,18 @@
 import Foundation
 
 struct ProfileDomainToDTOMapper {
-    func map(_ domain: Profile) -> ProfileDTO {
-        if let coachId = domain.coachId {
-            .init(name: domain.name,
-                  goal: domain.goal,
-                  coachId: coachId,
-                  age: domain.age,
-                  weight: domain.weight,
-                  height: domain.height
-            )
-        } else {
-            .init(name: domain.name)
+    func map(_ domain: Profile, role: Role) -> ProfileDTO {
+        switch role {
+        case .coach:
+                .init(name: domain.name)
+        case .trainee:
+                .init(name: domain.name,
+                      goal: domain.goal,
+                      coachId: domain.coachId,
+                      age: domain.age,
+                      weight: domain.weight,
+                      height: domain.height
+                )
         }
     }
 }

--- a/FitTrack_iOS/FitTrack_iOS/Data/Mappers/UserDomainToDTOMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Mappers/UserDomainToDTOMapper.swift
@@ -9,8 +9,7 @@ import Foundation
 
 struct UserDomainToDTOMapper {
     func map(_ domain: User) -> UserDTO {
-        .init(id: nil,
-              email: domain.email,
+        .init(email: domain.email,
               password: domain.password,
               role: RoleDTO(from: domain.role),
               profile: ProfileDomainToDTOMapper().map(domain.profile)

--- a/FitTrack_iOS/FitTrack_iOS/Data/Mappers/UserDomainToDTOMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Mappers/UserDomainToDTOMapper.swift
@@ -12,7 +12,7 @@ struct UserDomainToDTOMapper {
         .init(email: domain.email,
               password: domain.password,
               role: RoleDTO(from: domain.role),
-              profile: ProfileDomainToDTOMapper().map(domain.profile)
+              profile: ProfileDomainToDTOMapper().map(domain.profile, role: domain.role)
         )
     }
 }

--- a/FitTrack_iOS/FitTrack_iOS/Data/Models/UserDTO.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/Models/UserDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-enum RoleDTO: Encodable {
+enum RoleDTO: String, Encodable {
     case coach, trainee
     
     init(from role: Role) {
@@ -27,6 +27,18 @@ struct UserDTO: Encodable {
     let role: RoleDTO
     let profile: ProfileDTO
     
+    init(id: String? = nil,
+         email: String,
+         password: String,
+         role: RoleDTO,
+         profile: ProfileDTO) {
+        self.id = id
+        self.email = email
+        self.password = password
+        self.role = role
+        self.profile = profile
+    }
+    
     enum CodingKeys: String, CodingKey {
         case id, email, password, role, profile
     }
@@ -36,7 +48,7 @@ struct UserDTO: Encodable {
         try container.encodeIfPresent(id, forKey: .id)
         try container.encode(email, forKey: .email)
         try container.encode(password, forKey: .password)
-        try container.encode(role, forKey: .role)
+        try container.encode(role.rawValue, forKey: .role)
         try container.encode(profile, forKey: .profile)
     }
 }
@@ -49,6 +61,20 @@ struct ProfileDTO: Encodable {
     let weight: Double?
     let height: Double?
     
+    init(name: String,
+         goal: String? = nil,
+         coachId: String? = nil,
+         age: Int? = nil,
+         weight: Double? = nil,
+         height: Double? = nil) {
+        self.name = name
+        self.goal = goal
+        self.coachId = coachId
+        self.age = age
+        self.weight = weight
+        self.height = height
+    }
+    
     enum CodingKeys: String, CodingKey {
         case name, goal
         case coachId = "coach_id"
@@ -58,7 +84,7 @@ struct ProfileDTO: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
-        try container.encodeIfPresent(goal, forKey: .name)
+        try container.encodeIfPresent(goal, forKey: .goal)
         try container.encodeIfPresent(coachId, forKey: .coachId)
         try container.encodeIfPresent(age, forKey: .age)
         try container.encodeIfPresent(weight, forKey: .weight)

--- a/FitTrack_iOS/FitTrack_iOS/Domain/Entities/User.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Domain/Entities/User.swift
@@ -17,6 +17,18 @@ struct User {
     let password: String
     let role: Role
     let profile: Profile
+    
+    init(id: String? = nil,
+         email: String,
+         password: String,
+         role: Role,
+         profile: Profile) {
+        self.id = id
+        self.email = email
+        self.password = password
+        self.role = role
+        self.profile = profile
+    }
 }
 
 struct Profile {
@@ -26,4 +38,18 @@ struct Profile {
     let age: Int?
     let weight: Double?
     let height: Double?
+    
+    init(name: String,
+         goal: String? = nil,
+         coachId: String? = nil,
+         age: Int? = nil,
+         weight: Double? = nil,
+         height: Double? = nil) {
+        self.name = name
+        self.goal = goal
+        self.coachId = coachId
+        self.age = age
+        self.weight = weight
+        self.height = height
+    }
 }

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
@@ -51,7 +51,7 @@ final class URLRequestBuilder {
                     urlRequest.httpBody = try JSONEncoder().encode(body)
                     if let httpBody = urlRequest.httpBody,
                        let jsonString = String(data: httpBody, encoding: .utf8) {
-                        AppLogger.debug("HTTP Body created: \(jsonString)")
+                        AppLogger.debug("HTTP Body created: \(jsonString) sent to \(String(describing: urlRequest.url))")
                     }
                 } catch {
                     AppLogger.debug(error.localizedDescription)

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/URLRequestBuilder.swift
@@ -47,7 +47,16 @@ final class URLRequestBuilder {
             ].merging(urlRequestComponents.headers) { $1 }
             
             if let body = urlRequestComponents.body {
-                urlRequest.httpBody = try JSONEncoder().encode(body)
+                do {
+                    urlRequest.httpBody = try JSONEncoder().encode(body)
+                    if let httpBody = urlRequest.httpBody,
+                       let jsonString = String(data: httpBody, encoding: .utf8) {
+                        AppLogger.debug("HTTP Body created: \(jsonString)")
+                    }
+                } catch {
+                    AppLogger.debug(error.localizedDescription)
+                    throw APIError.decoding(url: urlRequestComponents.path)
+                }
             }
             
             return urlRequest


### PR DESCRIPTION
* Se resolvió bug en el que el `role` se estaba enviando como objeto en lugar de `string` (`rawValue`)
* Se aprovechó para agregar constructores a los modelos de `User` y `UserDTO` para agregar default values a los `nil` 
* Se corrigió envío de property `goal` en lugar de `name`
* Se agregó un log para mirar el `httpBody` en consola porque rayos con los proxies xd

**Signup Succeed**
<img width="604" height="119" alt="Captura de pantalla 2025-09-23 a las 9 19 28 p m" src="https://github.com/user-attachments/assets/25e6d6a3-4e6a-48aa-b4d2-bdd933816fff" />

**How to test:**
Copy and paste this code in AppState an run it
```
Task {
    do {
        let user = User(
            email: "user@keepcoding.es",
            password: "abcd12345",
            role: .coach,
            profile: Profile(
                name: "Alvaro Entrena"
            ))
        let useCase = SignupUseCase(authRepository: AuthRepository())
        let signup: () = try await useCase.run(user: user)
            debugPrint("Signup Succeed")
      } catch let error as AppError {
            AppLogger.debug(error.reason)
     } catch let error as APIError {
            AppLogger.debug(error.reason)
     } catch {
           AppLogger.debug(error.localizedDescription)
     }
}
```