### PR TITLE
Mobile: Fix Endpoint and Header Auth

### DIFF
--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/CreateTrainingURLRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct CreateTrainingURLRequest: URLRequestComponents {
     typealias Response = TrainingDTO
-    var path: String = "/api/trainings"
+    var path: String = "/api/training"
     var httpMethod: HTTPMethod = .POST
     var authorized: Bool = true
     var body: (any Encodable)?

--- a/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/SignupURLRequest.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Infraestructure/Networking/Requests/SignupURLRequest.swift
@@ -18,6 +18,7 @@ struct SignupURLRequest: URLRequestComponents {
         path = userDTO.role == .coach
         ? "/api/auth/register/coach"
         : "/api/auth/register/trainee"
+        authorized = userDTO.role == .trainee
         body = userDTO
     }
 }

--- a/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/TrainingRepositoryTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Data/Repository/TrainingRepositoryTests.swift
@@ -72,7 +72,7 @@ final class TrainingRepositoryTests: XCTestCase {
         
         // Then
         let badRequestAPIError = try XCTUnwrap(apiError)
-        XCTAssertEqual(badRequestAPIError.url, "/api/trainings")
+        XCTAssertEqual(badRequestAPIError.url, "/api/training")
         XCTAssertEqual(badRequestAPIError.reason, "The request could not be understood or was missing required parameters")
         XCTAssertEqual(badRequestAPIError.statusCode, 400)
     }

--- a/FitTrack_iOS/FitTrack_iOSTests/Domain/SignupUseCaseTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Domain/SignupUseCaseTests.swift
@@ -38,6 +38,20 @@ final class SignupUseCaseTests: XCTestCase {
         XCTAssertNotNil(successResponse)
     }
     
+    func testSignupTrainee_ReturnSuccess() async throws{
+        // Given
+        let user = UserData.givenTraineeUser
+        let fileURL = try XCTUnwrap(Bundle(for: SignupUseCaseTests.self).url(forResource: "jwt", withExtension: "json"))
+        let data = try XCTUnwrap(Data(contentsOf: fileURL))
+        mockAuthRepository.receivedData = data
+        
+        // When
+        let successResponse: () = try await sut.run(user: user)
+        
+        // Then
+        XCTAssertNotNil(successResponse)
+    }
+    
     func testSignup_WhenCredentialsAreInvalid_ShouldReturnRegexError() async throws {
         // Given
         let user = UserData.givenUserWithWrongEmail

--- a/FitTrack_iOS/FitTrack_iOSTests/Infraestructure/APISessionTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Infraestructure/APISessionTests.swift
@@ -137,7 +137,7 @@ final class APISessionTests: XCTestCase {
         let training = try await sut.request(createTrainingURLRequest)
         
         // Then
-        XCTAssertEqual(receivedRequest?.url?.path(), "/api/trainings")
+        XCTAssertEqual(receivedRequest?.url?.path(), "/api/training")
         XCTAssertEqual(receivedRequest?.httpMethod, "POST")
         let trainingDTO = try XCTUnwrap(training)
         XCTAssertEqual(trainingDTO.id, UUID(uuidString: "DAB7C5C0-0579-4D01-A01D-002D3F6D8985"))
@@ -171,7 +171,7 @@ final class APISessionTests: XCTestCase {
         
         // Then
         let badRequestAPIError = try XCTUnwrap(apiError)
-        XCTAssertEqual(badRequestAPIError.url, "/api/trainings")
+        XCTAssertEqual(badRequestAPIError.url, "/api/training")
         XCTAssertEqual(badRequestAPIError.reason, "The request could not be understood or was missing required parameters")
         XCTAssertEqual(badRequestAPIError.statusCode, 400)
     }

--- a/FitTrack_iOS/FitTrack_iOSTests/Stubs/UserData.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Stubs/UserData.swift
@@ -19,8 +19,19 @@ enum UserData {
         password: "abcd1234",
         role: .coach,
         profile: Profile(
-            name: "Alvaro",
-            goal: "Maratón de Madrid"
+            name: "Alvaro"
+        )
+    )
+    
+    static let givenTraineeUser = User(
+        email: "ari@gmail.com",
+        password: "abcd1234",
+        role: .trainee,
+        profile: Profile(
+            name: "Ari",
+            goal: "Maratón de Madrid",
+            weight: 54,
+            height: 1.70
         )
     )
     


### PR DESCRIPTION
Based on recent server changes we need to fix:

* Training POST endpoint 
* Request authorization token when we create a trainee

**Before**
<img width="768" height="128" alt="Captura de pantalla 2025-09-26 a las 12 12 28 p m" src="https://github.com/user-attachments/assets/92931673-80bb-4100-9a27-c3f77d7a416b" />

**After**
<img width="721" height="234" alt="Captura_de_pantalla_2025-09-27_a_las_6 17 31_p m" src="https://github.com/user-attachments/assets/c60e4ea5-f05d-474b-9938-3baa1be0cdb3" />
