### PR TITLE
Mobile: Fix has seen onboarding

### DIFF
--- a/FitTrack_iOS/FitTrack_iOS/Data/DataSources/AuthDataSource.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Data/DataSources/AuthDataSource.swift
@@ -23,6 +23,7 @@ final class AuthDataSource: AuthDataSourceProtocol {
             AppLogger.debug("Session not found or expired, log in again")
             throw AppError.session("Session not found or expired, log in again")
         }
+        AppLogger.debug("Session found, user is logged")
         return jwt
     }
     

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/AppState.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/AppState.swift
@@ -82,6 +82,7 @@ final class AppState: ObservableObject {
         let hasSeenOnBoarding = UserDefaults.standard.bool(forKey: "hasSeenOnboarding")
         if !hasSeenOnBoarding {
             status = .onBoarding
+            UserDefaults.standard.set(true, forKey: "hasSeenOnboarding")
             return
         }
         
@@ -91,7 +92,7 @@ final class AppState: ObservableObject {
             try await getSessionUseCase.run()
             status = .home
         } catch {
-            status = .login
+            status = .onBoarding
         }
     }
     


### PR DESCRIPTION
Dado que ahora tenemos un use case integrado para validar si un usuario tiene una sesión iniciada, se agregó como `true` la flag de `hasSeenOnboarding` para que después de ver esa pantalla, la próxima vez que el user abra la aplicación, vaya directo al `home` si tiene una sesión iniciada, de lo contrario se redirecciona a onboarding para que se pueda ver de nuevo también el registro.

| Before Fix   | After Fix |
| -------- | ------- |
 <img width="280" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-27 at 20 04 01" src="https://github.com/user-attachments/assets/2264ab3d-2b5b-48bd-86c2-eee2a527a2b3" /> | <img width="280" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-27 at 20 07 50" src="https://github.com/user-attachments/assets/bf4a3f2f-fb17-48b5-80ea-44f4d1522abc" /> 
