### PR TITLE
Mobile: Display trainees in view

### DIFF
--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Mappers/UserDomainToItemMapper.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Mappers/UserDomainToItemMapper.swift
@@ -1,0 +1,19 @@
+//
+//  TraineeDomainToUIMapper.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 27/09/25.
+//
+
+import Foundation
+
+struct UserDomainToItemMapper {
+    func map(_ domain: User) -> UserItem {
+        .init(
+            id: UUID(uuidString: domain.id ?? "") ?? UUID(),
+            clientImage: ["sarah", "joey_t", "benito_bodoque"].randomElement()!,
+            firstName: domain.profile.name,
+            lastName: ""
+        )
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/ClientsViewModel.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/ClientsViewModel.swift
@@ -7,8 +7,13 @@
 
 import Foundation
 
+protocol ClientsViewModelProtocol {
+    func load()
+    var clients: [UserItem] { get }
+}
+
 @Observable
-final class ClientsViewModel {
+final class ClientsViewModel: ClientsViewModelProtocol {
     private let getTraineesUseCase: GetTraineesUseCaseProtocol
     var clients: [UserItem]
     

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/ClientsViewModel.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/ViewModels/ClientsViewModel.swift
@@ -1,0 +1,34 @@
+//
+//  ClientsViewModel.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 27/09/25.
+//
+
+import Foundation
+
+@Observable
+final class ClientsViewModel {
+    private let getTraineesUseCase: GetTraineesUseCaseProtocol
+    var clients: [UserItem]
+    
+    init(getTraineesUseCase: GetTraineesUseCaseProtocol = GetTraineesUseCase()) {
+        self.getTraineesUseCase = getTraineesUseCase
+        self.clients = []
+    }
+    
+    func load() {
+        Task {
+            do {
+                let trainees = try await getTraineesUseCase.run()
+                clients = trainees.map {
+                    UserDomainToItemMapper().map($0)
+                }
+            } catch let error as AppError {
+                AppLogger.debug(error.reason)
+            } catch {
+                AppLogger.debug(error.localizedDescription)
+            }
+        }
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListView.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListView.swift
@@ -6,23 +6,22 @@
 //
 
 import SwiftUI
-// TODO: Use Real Models or future Mock Models
-struct Client: Identifiable {
+
+struct UserItem: Identifiable {
     let id: UUID
-    var clientImage: Image? = nil
+    var clientImage: String? = nil
     var firstName: String
     var lastName: String
 }
 
 struct ClientCell: View {
-    
-    var client: Client
+    var client: UserItem
     
     var body: some View {
         HStack {
             // If client image exists
             if let clientImage = client.clientImage {
-                clientImage
+                Image(clientImage)
                     .resizable()
                     .scaledToFill()          // Maintain proportion and fill the frame
                     .frame(width: 48, height: 48)
@@ -60,30 +59,9 @@ struct ClientCell: View {
 struct ClientsListView: View {
     // Used to hide Bottom Tab bar if needed
     @Binding var isTabBarHidden: Bool
-    // TODO: This will eventually be cleaned up and pulled from a mock located elsewhere.
-    let mockClients: [Client] = [
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Luis", lastName: "Quintero"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Ana", lastName: "García"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Carlos", lastName: "Pérez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Marta", lastName: "López"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Jorge", lastName: "Ramírez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Sofía", lastName: "Hernández"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "David", lastName: "Martínez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Lucía", lastName: "González"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Fernando", lastName: "Torres"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Carla", lastName: "Vargas"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Miguel", lastName: "Rojas"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Valeria", lastName: "Castillo"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Andrés", lastName: "Molina"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Paula", lastName: "Santos"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Tomás", lastName: "Alvarado"),
-        Client(id: UUID(), clientImage: Image("sarah"), firstName: "Ana", lastName: "Ganfornina"),
-        Client(id: UUID(), clientImage: Image("sarah"), firstName: "Ana", lastName: "Ganfornina"),
-        Client(id: UUID(), firstName: "Sarah", lastName: "Ganfornina")
-    ]
-    
     // Text varibale used to search Clients
     @State private var searchText = ""
+    @State var clientsViewModel: ClientsViewModel
     
     /// Filtered and sorted list of clients based on the search text.
     ///
@@ -96,10 +74,10 @@ struct ClientsListView: View {
     /// The final list is sorted alphabetically:
     /// 1. By `firstName`.
     /// 2. If two clients have the same `firstName`, then by `lastName`.
-    var filteredList: [Client] {
+    var filteredList: [UserItem] {
         let list = searchText.isEmpty
-        ? mockClients
-        : mockClients.filter {
+        ? clientsViewModel.clients
+        : clientsViewModel.clients.filter {
             /// `lowerSearch` used to  convert everything to lowercase for case-insensitive comparison
             let lowerSeach = searchText.lowercased()
             let firstName = $0.firstName.lowercased() // Name
@@ -126,7 +104,7 @@ struct ClientsListView: View {
     /// - Uses `filteredList` as the source, so only clients that match the search text are included.
     /// - The key is the first letter of the `firstName`. Uppercased as Default
     /// - The value is an array of `Client` objects whose `firstName` starts with that letter.
-    var groupedClients: [String: [Client]] {
+    var groupedClients: [String: [UserItem]] {
         Dictionary(grouping: filteredList) { client in
             String(client.firstName.prefix(1)) // Letter in each section (A, B, C)
         }
@@ -159,11 +137,16 @@ struct ClientsListView: View {
             .searchable(text: $searchText, prompt: "Buscar clientes") // Searchbar Hint Text
             .listStyle(.inset) // Remove gray list color
             .padding(.bottom, 24) // Used to end Client List at the same height as the MainTabBar Divider
+        }.onAppear {
+            clientsViewModel.load()
         }
     }
 }
 
 
 #Preview {
-    ClientsListView(isTabBarHidden: .constant(false))
+    ClientsListView(
+        isTabBarHidden: .constant(false),
+        clientsViewModel: ClientsViewModel()
+    )
 }

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListView.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListView.swift
@@ -61,7 +61,7 @@ struct ClientsListView: View {
     @Binding var isTabBarHidden: Bool
     // Text varibale used to search Clients
     @State private var searchText = ""
-    @State var clientsViewModel: ClientsViewModel
+    @State var clientsViewModel: ClientsViewModelProtocol
     
     /// Filtered and sorted list of clients based on the search text.
     ///

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListViewPicker.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListViewPicker.swift
@@ -6,17 +6,16 @@
 //
 
 import SwiftUI
-// TODO: Use Real Models or future Mock Models -> Now is obtaining data from Struct "Client" inside ClientsListView
 
 struct ClientCellPicker: View {
     
-    var client: Client
+    var client: UserItem
     
     var body: some View {
         HStack {
             // If client image exists
             if let clientImage = client.clientImage {
-                clientImage
+                Image(clientImage)
                     .resizable()
                     .scaledToFill()          // Maintain proportion and fill the frame
                     .frame(width: 48, height: 48)
@@ -57,27 +56,7 @@ struct ClientsListViewPicker: View {
     // Used to hide Bottom Tab bar if needed
     @Binding var isTabBarHidden: Bool
     @Environment(\.dismiss) private var dismiss // DismissView
-    // TODO: This will eventually be cleaned up and pulled from a mock located elsewhere.
-    let mockClients: [Client] = [
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Luis", lastName: "Quintero"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Ana", lastName: "García"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Carlos", lastName: "Pérez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Marta", lastName: "López"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Jorge", lastName: "Ramírez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Sofía", lastName: "Hernández"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "David", lastName: "Martínez"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Lucía", lastName: "González"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Fernando", lastName: "Torres"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Carla", lastName: "Vargas"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Miguel", lastName: "Rojas"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Valeria", lastName: "Castillo"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Andrés", lastName: "Molina"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Paula", lastName: "Santos"),
-        Client(id: UUID(), clientImage: Image(["sarah", "joey_t", "benito_bodoque"].randomElement()!), firstName: "Tomás", lastName: "Alvarado"),
-        Client(id: UUID(), clientImage: Image("sarah"), firstName: "Ana", lastName: "Ganfornina"),
-        Client(id: UUID(), clientImage: Image("sarah"), firstName: "Ana", lastName: "Ganfornina"),
-        Client(id: UUID(), firstName: "Sarah", lastName: "Ganfornina")
-    ]
+    @State var clientsViewModel: ClientsViewModel
     
     // Text varibale used to search Clients
     @State private var searchText = ""
@@ -93,10 +72,10 @@ struct ClientsListViewPicker: View {
     /// The final list is sorted alphabetically:
     /// 1. By `firstName`.
     /// 2. If two clients have the same `firstName`, then by `lastName`.
-    var filteredList: [Client] {
+    var filteredList: [UserItem] {
         let list = searchText.isEmpty
-        ? mockClients
-        : mockClients.filter {
+        ? clientsViewModel.clients
+        : clientsViewModel.clients.filter {
             /// `lowerSearch` used to  convert everything to lowercase for case-insensitive comparison
             let lowerSeach = searchText.lowercased()
             let firstName = $0.firstName.lowercased() // Name
@@ -123,7 +102,7 @@ struct ClientsListViewPicker: View {
     /// - Uses `filteredList` as the source, so only clients that match the search text are included.
     /// - The key is the first letter of the `firstName`. Uppercased as Default
     /// - The value is an array of `Client` objects whose `firstName` starts with that letter.
-    var groupedClients: [String: [Client]] {
+    var groupedClients: [String: [UserItem]] {
         Dictionary(grouping: filteredList) { client in
             String(client.firstName.prefix(1)) // Letter in each section (A, B, C)
         }
@@ -158,12 +137,19 @@ struct ClientsListViewPicker: View {
             .searchable(text: $searchText, prompt: "Buscar clientes") // Searchbar Hint Text
             .listStyle(.inset) // Remove gray list color
             .padding(.bottom, 24) // Used to end Client List at the same height as the MainTabBar Divider
-            .onAppear { isTabBarHidden = true }   // Hides TabBar
+            .onAppear {
+                isTabBarHidden = true // Hides TabBar
+                clientsViewModel.load()
+            }
         }
     }
 }
 
 
 #Preview {
-    ClientsListViewPicker(selectedClient: .constant(nil), isTabBarHidden: .constant(false))
+    ClientsListViewPicker(
+        selectedClient: .constant(nil),
+        isTabBarHidden: .constant(false),
+        clientsViewModel: ClientsViewModel()
+    )
 }

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListViewPicker.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Clients/ClientsListViewPicker.swift
@@ -56,7 +56,7 @@ struct ClientsListViewPicker: View {
     // Used to hide Bottom Tab bar if needed
     @Binding var isTabBarHidden: Bool
     @Environment(\.dismiss) private var dismiss // DismissView
-    @State var clientsViewModel: ClientsViewModel
+    @State var clientsViewModel: ClientsViewModelProtocol
     
     // Text varibale used to search Clients
     @State private var searchText = ""

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Exercises/NewTrainingView.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Exercises/NewTrainingView.swift
@@ -31,10 +31,9 @@ struct NewTrainingView: View {
                     NavigationLink(
                         destination: ClientsListViewPicker(
                             selectedClient: $selectedClient,
-                            isTabBarHidden: $isTabBarHidden
-                            
+                            isTabBarHidden: $isTabBarHidden,
+                            clientsViewModel: ClientsViewModel()
                         )
-                        
                     ) {
                         VStack {
                             Text("Cliente")

--- a/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Home /TabBar/MainTabBar.swift
+++ b/FitTrack_iOS/FitTrack_iOS/Presentation/Views/Home /TabBar/MainTabBar.swift
@@ -21,7 +21,7 @@ struct MainTabBar: View {
                 case 0:
                     HomeView(isTabBarHidden: $isTabBarHidden)
                 case 1:
-                    ClientsListView(isTabBarHidden: $isTabBarHidden)
+                    ClientsListView(isTabBarHidden: $isTabBarHidden, clientsViewModel: ClientsViewModel())
                 case 2:
                     ExerciseListView(isTabBarHidden: $isTabBarHidden)
                 default:

--- a/FitTrack_iOS/FitTrack_iOSTests/Domain/Mock/MockGetTraineesUseCase.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Domain/Mock/MockGetTraineesUseCase.swift
@@ -1,0 +1,21 @@
+//
+//  MockGetTraineesUseCase.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 28/09/25.
+//
+
+import XCTest
+@testable import FitTrack_iOS
+
+final class MockGetTraineesUseCase: GetTraineesUseCaseProtocol {
+    var dataReceived: [User]?
+    
+    func run() async throws -> [User] {
+        guard let dataReceived else {
+            return []
+        }
+        
+        return dataReceived
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/ClientsViewModelTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/ClientsViewModelTests.swift
@@ -1,0 +1,63 @@
+//
+//  ClientsViewModel.swift
+//  FitTrack_iOS
+//
+//  Created by Ariana Rodríguez on 28/09/25.
+//
+
+import XCTest
+@testable import FitTrack_iOS
+
+final class ClientsViewModelTests: XCTestCase {
+    var sut: ClientsViewModelProtocol!
+    var mockGetTraineesUseCase: MockGetTraineesUseCase!
+    
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockGetTraineesUseCase = MockGetTraineesUseCase()
+        sut = ClientsViewModel(getTraineesUseCase: mockGetTraineesUseCase)
+    }
+    
+    override func tearDownWithError() throws {
+        mockGetTraineesUseCase = nil
+        sut = nil
+        try super.tearDownWithError()
+    }
+    
+    func test_userDomain_mappedToItem() {
+        // Given
+        let user = UserData.givenUser
+        
+        // When
+        let userItem = UserDomainToItemMapper().map(user)
+        
+        // Then
+        XCTAssertEqual(user.profile.name, userItem.firstName)
+    }
+    
+    func test_loadTrainees_Succeed() async throws {
+        // Given
+        mockGetTraineesUseCase.dataReceived = UserData.givenUsers
+        
+        // When
+        sut.load()
+        try await Task.sleep(for: .seconds(0.1))
+        
+        // Then
+        XCTAssertEqual(sut.clients.count, 3)
+        XCTAssertEqual(sut.clients.first?.firstName, "Ari")
+    }
+    
+    func test_loadTrainees_ShouldReturnEmpty() async throws {
+        // Given
+        mockGetTraineesUseCase.dataReceived = []
+        
+        // When
+        sut.load()
+        try await Task.sleep(for: .seconds(0.1))
+        
+        // Then
+        XCTAssertEqual(sut.clients.count, 0)
+        XCTAssertNil(sut.clients.first?.firstName)
+    }
+}

--- a/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/ClientsViewModelTests.swift
+++ b/FitTrack_iOS/FitTrack_iOSTests/Presentation/ViewModels/ClientsViewModelTests.swift
@@ -38,12 +38,25 @@ final class ClientsViewModelTests: XCTestCase {
     func test_loadTrainees_Succeed() async throws {
         // Given
         mockGetTraineesUseCase.dataReceived = UserData.givenUsers
+        let loadingExpectation = expectation(description: "Loading state succeed")
+        let loadedExpectation = expectation(description: "Loaded state succeed")
         
         // When
+        sut.onStateChanged = { state in
+            switch state {
+            case .loading:
+                loadingExpectation.fulfill()
+            case .loaded:
+                loadedExpectation.fulfill()
+            default:
+                XCTFail("Loaded state is expected")
+            }
+        }
+        
         sut.load()
-        try await Task.sleep(for: .seconds(0.1))
         
         // Then
+        await fulfillment(of: [loadingExpectation, loadedExpectation], timeout: 0.1)
         XCTAssertEqual(sut.clients.count, 3)
         XCTAssertEqual(sut.clients.first?.firstName, "Ari")
     }
@@ -51,12 +64,25 @@ final class ClientsViewModelTests: XCTestCase {
     func test_loadTrainees_ShouldReturnEmpty() async throws {
         // Given
         mockGetTraineesUseCase.dataReceived = []
+        let loadingExpectation = expectation(description: "Loading state succeed")
+        let loadedExpectation = expectation(description: "Loaded state succeed")
         
         // When
+        sut.onStateChanged = { state in
+            switch state {
+            case .loading:
+                loadingExpectation.fulfill()
+            case .loaded:
+                loadedExpectation.fulfill()
+            default:
+                XCTFail("Loaded state is expected")
+            }
+        }
+        
         sut.load()
-        try await Task.sleep(for: .seconds(0.1))
         
         // Then
+        await fulfillment(of: [loadingExpectation, loadedExpectation], timeout: 0.1)
         XCTAssertEqual(sut.clients.count, 0)
         XCTAssertNil(sut.clients.first?.firstName)
     }


### PR DESCRIPTION
* Se renombró el modelo `Client` por `UserItem` para tener asociado el modelo **User** e **Item** de lista
* Se creó un Mapper en la capa de **Presentación** para transformar un modelo de `User` a `UserItem` y pintar lo que la UI necesita
* Se creó un `ClientsViewModel` que se compartió entre `ClientsListView` y `ClientListViewPicker`

| TabBar/Clients   | NewTraining/Clients |
| -------- | ------- |
 <img width="280" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-27 at 20 04 01" src="https://github.com/user-attachments/assets/db3c3634-525a-403a-9c46-9e958881b6c8" /> | <img width="280" height="600" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-27 at 20 07 50" src="https://github.com/user-attachments/assets/d59d7926-7d23-4dda-89ab-7d09fe74d037" /> 

**Tests**
<img width="400" height="111" alt="Captura de pantalla 2025-09-28 a las 12 48 33 a m" src="https://github.com/user-attachments/assets/d28198cb-389d-4c6b-887d-a5dee02decc7" />